### PR TITLE
Update Call.sol

### DIFF
--- a/src/pages/call/Call.sol
+++ b/src/pages/call/Call.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.7.6;
 contract Receiver {
     event Received(address caller, uint amount, string message);
 
-    receive() external payable {
+    fallback() external payable {
         emit Received(msg.sender, msg.value, "Fallback was called");
     }
 


### PR DESCRIPTION
It is probably a typo I guess, a fallback function should be "fallback() external payable" instead of "receive() external payable" in solidity 0.7.6.